### PR TITLE
Restrict ids for sensors and actuators

### DIFF
--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -95,7 +95,7 @@ class Bridge():
             datatype += self.inbuffer[4 + i].decode("ascii")
 
         data_json = {}
-        data_json['bridge'] = str(self.name)
+        data_json['bridgeid'] = str(self.name)
 
         data_json['sensor'] = "True" if sensor else "False"
     
@@ -137,7 +137,7 @@ class Bridge():
                 print("Datasize not matching: ", datasize, len(self.inbuffer))
 
         # send the read data as json to the cloud
-        data_json = currentData.getJSON()
+        data_json = currentData.getJSON(self.name)
 
         if(not self.debug):
             response = requests.post(self.cloud + '/addvalue', json=data_json)
@@ -151,6 +151,7 @@ class Bridge():
             time.sleep(30)
 
             data_json = {}
+            data_json['bridgeid'] = str(self.name)
             data_json['actuator_num'] = str(len(self.actuators))
             data_json['actuators'] = [str(actuator) for actuator in self.actuators]
             response = requests.post(self.cloud + '/getNewValues', json=data_json)

--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -24,6 +24,19 @@ class Bridge():
         self.inbuffer = []
         self.state = "addValueForSensor"
 
+        self.sendInitializeMessageToCloud()
+
+    def sendInitializeMessageToCloud(self):
+        data_json = {}
+        data_json['bridgeid'] = str(self.name)
+        self.sendToCloud('initializebridge', data_json)
+        print("Initialized Bridge")
+
+    def sendToCloud(self, path, json_data):
+        response = requests.post(self.cloud + '/' + path, json=json_data)
+        return response
+
+
     async def asyncFunctions(self):
         callables = [self.serialHandler.loop, self.queryForNewActuatorValues]
         await asyncio.gather(*map(asyncio.to_thread, callables))
@@ -103,8 +116,12 @@ class Bridge():
         print("json_data for initilization: ", data_json)
 
         if (not self.debug):
-            response = requests.post(self.cloud + '/adddevice', json=data_json)
+            response = self.sendToCloud('adddevice', data_json)
             device_id = int(response.content) # TODO: answer in a nicer machine readable way
+
+            if(device_id > 253):
+                print("Warning: to many devices initialized for that bridge and device id to high for serial communication")
+                return
             
             if (sensor):
                 flags = 128
@@ -140,7 +157,7 @@ class Bridge():
         data_json = currentData.getJSON(self.name)
 
         if(not self.debug):
-            response = requests.post(self.cloud + '/addvalue', json=data_json)
+            response = self.sendToCloud('addvalue', data_json)
             if (not response.ok):
                 print("Something went wrong uploading the data. See statuscode " + response.reason)
         else:
@@ -154,7 +171,7 @@ class Bridge():
             data_json['bridgeid'] = str(self.name)
             data_json['actuator_num'] = str(len(self.actuators))
             data_json['actuators'] = [str(actuator) for actuator in self.actuators]
-            response = requests.post(self.cloud + '/getNewValues', json=data_json)
+            response = self.sendToCloud('getNewValues', data_json)
 
             # expecting json like {'actuator_number' : 'actuator_value'}
             print("Queried cloud for new Values for actuators")

--- a/bridge/data/data.py
+++ b/bridge/data/data.py
@@ -10,9 +10,10 @@ class DataSet():
 	def addValue(self, value):
 		self.data.append(value)
 
-	def getJSON(self):
+	def getJSON(self, bridge_name):
 		# creating json like data
 		data = {}
+		data['bridgeid'] = str(bridge_name)
 		data['sensorid'] = str(self.sensorid)
 		data['datasize'] = str(self.datasize())
 		data['data'] = [str(datapoint) for datapoint in self.data]


### PR DESCRIPTION
Due to the serial protocol we can not send higher ids than fit into one byte so one bridge can only have 253 sensors since \xFF and \xFE are reserved

- [ ] Change database in a way that sensorfeeds are casced deleted if sensor is deleted